### PR TITLE
test: add pytest suite; make config import side-effect free

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@
 *.png
 /activation_matrices
 /.idea
+.idea/
+.vscode/
+.venv/
+venv/
+__pycache__/
+*.py[cod]
+.pytest_cache/

--- a/config.py
+++ b/config.py
@@ -70,4 +70,16 @@ def config_data():
     return sub_train_list_, sub_test_list_
 
 
-sub_train_list, sub_test_list = config_data()
+# The train/test subject split is derived from a data pickle. Compute it lazily on
+# first access (PEP 562) so that importing `config` does not require the data file to
+# be present — importing the module stays side-effect free.
+_subject_split = None
+
+
+def __getattr__(name):
+    global _subject_split
+    if name in ('sub_train_list', 'sub_test_list'):
+        if _subject_split is None:
+            _subject_split = config_data()
+        return _subject_split[0] if name == 'sub_train_list' else _subject_split[1]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+testpaths = tests
+addopts = -q
+filterwarnings =
+    ignore::FutureWarning
+    ignore::DeprecationWarning

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+"""Shared test setup for the LSTM-activations-analysis suite.
+
+Tests exercise the pure arithmetic / algorithmic functions on small synthetic inputs. Some
+production code calls ``matplotlib.pyplot.show()``, so a non-interactive backend keeps the run
+headless. The repo root is added to ``sys.path`` so top-level modules import as in production.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import matplotlib
+
+matplotlib.use("Agg")  # no interactive windows during tests

--- a/tests/test_cc_utils.py
+++ b/tests/test_cc_utils.py
@@ -1,0 +1,44 @@
+"""model_training.cc_utils — pure clip-classification helpers (no model/torch forward pass)."""
+import numpy as np
+import pandas as pd
+
+from model_training.cc_utils import (
+    _get_clip_labels,
+    _get_mask,
+    _get_t_acc,
+    _test_time_window,
+)
+
+
+def test_get_mask_marks_valid_positions():
+    mask = _get_mask([2, 3], max_length=4)
+    assert mask.tolist() == [[1, 1, 0, 0], [1, 1, 1, 0]]
+
+
+def test_get_t_acc_per_time_position():
+    y = [0, 1, 2, 0, 1, 2]
+    y_hat = [0, 1, 9, 0, 9, 2]
+    acc = _get_t_acc(y_hat, y, k_time=3)
+    assert acc.tolist() == [1.0, 0.5, 0.5]
+
+
+def test_get_clip_labels_testretest_is_zero_rest_incremental():
+    timing = pd.DataFrame({
+        "run": ["MOVIE1_7T_AP", "MOVIE1_7T_AP", "MOVIE2_7T_PA"],
+        "clip_name": ["testretest1", "twomen", "bridgeville"],
+    })
+    assert _get_clip_labels(timing) == {"testretest1": 0, "twomen": 1, "bridgeville": 2}
+
+
+def test_test_time_window_shifts_when_start_nonzero():
+    df = pd.DataFrame({"timepoint": [0, 1, 2, 3, 4, 5], "v": [10, 11, 12, 13, 14, 15]})
+    out = _test_time_window(df, range(2, 5))
+    assert out["timepoint"].tolist() == [0, 1, 2]  # shifted by start=2
+    assert out["v"].tolist() == [12, 13, 14]
+
+
+def test_test_time_window_no_shift_when_start_zero():
+    df = pd.DataFrame({"timepoint": [0, 1, 2, 3], "v": [10, 11, 12, 13]})
+    out = _test_time_window(df, range(0, 3))
+    assert out["timepoint"].tolist() == [0, 1, 2]
+    assert out["v"].tolist() == [10, 11, 12]

--- a/tests/test_data_mappings.py
+++ b/tests/test_data_mappings.py
@@ -1,0 +1,13 @@
+"""mappings.data_mappings._occurrence_subject_mapping — subject -> [indices] accumulation."""
+import mappings.data_mappings as dm
+
+
+def test_occurrence_subject_mapping_accumulates_per_subject():
+    dm.SUBJECT_TO_OCCURRENCE_MAPPING.clear()
+    try:
+        dm._occurrence_subject_mapping("s1", 0)
+        dm._occurrence_subject_mapping("s1", 5)
+        dm._occurrence_subject_mapping("s2", 2)
+        assert dm.SUBJECT_TO_OCCURRENCE_MAPPING == {"s1": [0, 5], "s2": [2]}
+    finally:
+        dm.SUBJECT_TO_OCCURRENCE_MAPPING.clear()

--- a/tests/test_math_functions.py
+++ b/tests/test_math_functions.py
@@ -1,0 +1,35 @@
+"""statistical_analysis.math_functions — z_score and pearson_correlation.
+
+These pin *current* behavior. `pearson_correlation` is almost certainly buggy (see the note on
+its test) and is revisited in the bug-fix phase.
+"""
+import numpy as np
+import pandas as pd
+
+from statistical_analysis.math_functions import pearson_correlation, z_score
+
+
+def test_z_score_centers_and_scales_by_population_std():
+    seq = np.array([1.0, 2.0, 3.0])
+    z = z_score(seq)
+    assert np.isclose(z.mean(), 0.0)
+    # np.std defaults to population std (ddof=0)
+    assert np.allclose(z, (seq - seq.mean()) / seq.std())
+
+
+def test_z_score_constant_sequence_is_nan():
+    # zero std -> division by zero -> nan (documents current behavior)
+    z = z_score(np.array([5.0, 5.0, 5.0]))
+    assert np.isnan(z).all()
+
+
+def test_pearson_correlation_current_behavior():
+    # BUG (pinned): `(1/len(seq)-1)` parses as (1/len)-1 rather than 1/(len-1), and
+    # `seq.T * seq` is an element-wise product, not a matrix/correlation product. So this
+    # does not compute a Pearson correlation. Locked here as-is; fixed in the bug-fix phase.
+    seq = pd.DataFrame([[1.0, 2.0], [3.0, 4.0]])
+    out = pearson_correlation(seq)
+    expected = (1 / len(seq) - 1) * (seq.T * seq)
+    pd.testing.assert_frame_equal(out, expected)
+    # concretely, for this input:
+    assert out.values.tolist() == [[-0.5, -3.0], [-3.0, -8.0]]

--- a/tests/test_matrices_ops.py
+++ b/tests/test_matrices_ops.py
@@ -1,0 +1,60 @@
+"""statistical_analysis.matrices_ops.MatricesOperations — correlation / matrix helpers."""
+import numpy as np
+import pandas as pd
+import pytest
+
+from statistical_analysis.matrices_ops import MatricesOperations as MO
+
+
+def test_is_symmetric():
+    assert MO.is_symmetric(np.array([[1.0, 2.0], [2.0, 1.0]]))
+    assert not MO.is_symmetric(np.array([[1.0, 2.0], [3.0, 1.0]]))
+
+
+def test_correlation_matrix():
+    df = pd.DataFrame({"a": [1.0, 2.0, 3.0], "b": [3.0, 2.0, 1.0]})
+    corr = MO.correlation_matrix(df)
+    assert np.isclose(corr.loc["a", "b"], -1.0)
+    assert np.isclose(corr.loc["a", "a"], 1.0)
+
+
+def test_cross_correlation_matrix_pairs_columns():
+    m1 = pd.DataFrame({"a": [1.0, 2, 3, 4], "b": [4.0, 3, 2, 1]})
+    m2 = pd.DataFrame({"a": [1.0, 2, 3, 4], "b": [1.0, 2, 3, 4]})
+    out = MO.cross_correlation_matrix(m1, m2)
+    assert np.isclose(out["a"], 1.0)   # identical column -> +1
+    assert np.isclose(out["b"], -1.0)  # reversed column -> -1
+
+
+def test_flatten_matrix():
+    assert MO.flatten_matrix(np.array([[1, 2], [3, 4]])).tolist() == [1, 2, 3, 4]
+
+
+def test_get_avg_matrix_over_iterable():
+    mats = [np.array([[1.0, 1], [1, 1]]), np.array([[3.0, 3], [3, 3]])]
+    assert np.allclose(MO.get_avg_matrix(iter(mats)), 2.0)
+
+
+def test_get_avg_vector():
+    assert np.isclose(MO.get_avg_vector(pd.Series([1.0, 2.0, 3.0])), 2.0)
+
+
+def test_drop_symmetric_drops_diagonal_by_default():
+    m = pd.DataFrame(np.array([[1.0, 2, 3], [2, 4, 5], [3, 5, 6]]))
+    out = MO.drop_symmetric_side_of_a_matrix(m.copy(), drop_diagonal=True)
+    # strictly-lower triangle (diagonal removed)
+    assert out.tolist() == [2.0, 3.0, 5.0]
+
+
+def test_drop_symmetric_keeps_diagonal_when_requested():
+    m = pd.DataFrame(np.array([[1.0, 2, 3], [2, 4, 5], [3, 5, 6]]))
+    out = MO.drop_symmetric_side_of_a_matrix(m.copy(), drop_diagonal=False)
+    # full lower triangle including the diagonal
+    assert out.tolist() == [1.0, 2.0, 4.0, 3.0, 5.0, 6.0]
+
+
+def test_drop_symmetric_on_nonsymmetric_raises():
+    m = pd.DataFrame(np.array([[1.0, 2.0], [3.0, 4.0]]))
+    # BUG (pinned): `raise(ValueError, msg)` raises a tuple -> TypeError, not ValueError.
+    with pytest.raises(TypeError):
+        MO.drop_symmetric_side_of_a_matrix(m)

--- a/tests/test_re_arranging.py
+++ b/tests/test_re_arranging.py
@@ -1,0 +1,37 @@
+"""mappings.re_arranging.rearrange_clips — clip/rest column (or row) ordering."""
+import pandas as pd
+
+from mappings.re_arranging import rearrange_clips
+
+CLIPS = ["twomen", "bridgeville", "pockets", "overcome", "inception", "socialnet", "oceans",
+         "flower", "hotel", "garden", "dreary", "homealone", "brokovich", "starwars"]
+
+
+def _expected_order(with_testretest):
+    clips = [f"{c}_clips" for c in CLIPS]
+    rests = [f"{c}_rest_between" for c in CLIPS]
+    if with_testretest:
+        clips += [f"testretest{i}_clips" for i in (1, 2, 3, 4)]
+        rests += [f"testretest{i}_rest_between" for i in (1, 2, 3, 4)]
+    return clips + rests
+
+
+def test_rearrange_columns_default_no_testretest():
+    exp = _expected_order(with_testretest=False)
+    df = pd.DataFrame([[0] * len(exp)], columns=list(reversed(exp)))
+    out = rearrange_clips(df)
+    assert list(out.columns) == exp
+
+
+def test_rearrange_columns_with_testretest():
+    exp = _expected_order(with_testretest=True)
+    df = pd.DataFrame([[0] * len(exp)], columns=list(reversed(exp)))
+    out = rearrange_clips(df, with_testretest=True)
+    assert list(out.columns) == exp
+
+
+def test_rearrange_rows():
+    exp = _expected_order(with_testretest=False)
+    df = pd.DataFrame({"v": [0] * len(exp)}, index=list(reversed(exp)))
+    out = rearrange_clips(df, where="rows")
+    assert list(out.index) == exp

--- a/tests/test_relational_coding_base.py
+++ b/tests/test_relational_coding_base.py
@@ -1,0 +1,44 @@
+"""relational_coding.relational_coding_base.RelationalCoding — pure helpers."""
+import numpy as np
+import pandas as pd
+
+from relational_coding.relational_coding_base import RelationalCoding as RC
+
+
+def _clip_table():
+    return pd.DataFrame({
+        "Subject": ["s1"] * 6,
+        "y": [1, 1, 1, 2, 2, 2],
+        "timepoint": [0, 1, 2, 0, 1, 2],
+        "v0": [10, 11, 12, 20, 21, 22],
+        "v1": [30, 31, 32, 40, 41, 42],
+    })
+
+
+def test_get_single_tr_defaults_to_last_timepoint():
+    out = RC.get_single_tr(_clip_table(), clip_i=1, tr_field="timepoint")
+    assert list(out.columns) == ["v0", "v1"]     # metadata columns dropped
+    assert out.values.tolist() == [[12, 32]]      # last TR (timepoint 2) of clip 1
+
+
+def test_get_single_tr_explicit_timepoint():
+    out = RC.get_single_tr(_clip_table(), clip_i=2, tr_field="timepoint", tr_pos=0)
+    assert out.values.tolist() == [[20, 40]]
+
+
+def test_relational_distance_of_correlated_quadrants():
+    # 6x6 with symmetric clip quadrant (top-left) and rest quadrant (bottom-right) whose
+    # strictly-lower triangles are perfectly correlated ([1,2,3] vs [2,4,6]) -> distance 1.0
+    clip = np.array([[1, 1, 2], [1, 1, 3], [2, 3, 1]], float)
+    rest = np.array([[1, 2, 4], [2, 1, 6], [4, 6, 1]], float)
+    full = np.zeros((6, 6))
+    full[:3, :3] = clip
+    full[3:, 3:] = rest
+    assert RC.relational_distance(pd.DataFrame(full)) == 1.0
+
+
+def test_shuffle_clips_mapping_wraps_around():
+    assert RC._shuffle_clips(1) == 3
+    assert RC._shuffle_clips(13) == 1
+    assert RC._shuffle_clips(14) == 2
+    assert RC._shuffle_clips(99) is None  # unknown index -> None

--- a/tests/test_supporting_functions.py
+++ b/tests/test_supporting_functions.py
@@ -1,0 +1,20 @@
+"""supporting_functions — pickle/csv I/O helpers (round-trip on a tmp path)."""
+import pandas as pd
+
+from supporting_functions import _dict_to_pkl, _load_csv, _load_pkl
+
+
+def test_dict_to_pkl_load_pkl_roundtrip(tmp_path):
+    data = {"a": 1, "b": [1, 2, 3]}
+    stem = tmp_path / "obj"
+    _dict_to_pkl(data, str(stem))            # appends .pkl
+    loaded = _load_pkl(f"{stem}.pkl")
+    assert loaded == data
+
+
+def test_load_csv(tmp_path):
+    csv = tmp_path / "t.csv"
+    pd.DataFrame({"a": [1, 2], "b": [3, 4]}).to_csv(csv, index=False)
+    out = _load_csv(str(csv))
+    assert out["a"].tolist() == [1, 2]
+    assert out["b"].tolist() == [3, 4]

--- a/tests/test_torch_utils.py
+++ b/tests/test_torch_utils.py
@@ -1,0 +1,20 @@
+"""model_training.torch_utils._to_cpu — detach/clone a tensor onto the CPU."""
+import numpy as np
+import torch
+
+from model_training.torch_utils import _to_cpu
+
+
+def test_to_cpu_returns_detached_cpu_tensor():
+    t = torch.tensor([1.0, 2.0, 3.0], requires_grad=True)
+    out = _to_cpu(t)
+    assert not out.requires_grad
+    assert out.device.type == "cpu"
+    assert np.allclose(out.numpy(), [1.0, 2.0, 3.0])
+
+
+def test_to_cpu_clones_by_default():
+    t = torch.tensor([1.0, 2.0, 3.0])
+    out = _to_cpu(t)          # clone=True -> independent storage
+    out[0] = 99.0
+    assert t[0].item() == 1.0  # original untouched


### PR DESCRIPTION
## What & why

First phase of the renovation (tests-first), same approach as the fmri-relational-coding repo.

- **`config.py` unblocked**: the train/test subject split was computed **at import time** via `pd.read_pickle('.../4_runs_rest_between.pkl')`. Since 21 modules import `config`, *nothing was importable (or testable) without that data file*. It's now computed lazily on first attribute access (PEP 562 `__getattr__`), so `config.sub_train_list` / `sub_test_list` still work but importing `config` is side-effect free.
- **Test harness**: `pytest.ini` + `tests/conftest.py` (repo root on `sys.path`, headless matplotlib).
- **29 characterization tests** pinning current behavior of the pure algorithm/helper code: `math_functions`, `matrices_ops`, `mappings.re_arranging`, `mappings.data_mappings`, `relational_coding_base`, and (per scope) `model_training.cc_utils`, `model_training.torch_utils`, `supporting_functions`.
- **`.gitignore`**: add `.venv/`, `__pycache__/`, `.pytest_cache/`, editor dirs.

## Bugs surfaced (pinned as current behavior, fixed next phase)
- `matrices_ops.drop_symmetric_side_of_a_matrix` raises **`TypeError`** instead of `ValueError` — `raise(ValueError, msg)` raises a tuple.
- `math_functions.pearson_correlation` — `(1/len(seq)-1)` parses as `(1/len)-1`, and `seq.T * seq` is element-wise; it does not compute a Pearson correlation.
- `matrices_ops.generate_heat_map` calls `plt.show()` inline.

## Verification
- **29 tests pass** (`pytest`). Environment set up with `uv` (Python 3.10, torch 1.12.1 + scientific stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)