### PR TITLE
fix: drop_symmetric error path/mutation + pearson_correlation

### DIFF
--- a/statistical_analysis/math_functions.py
+++ b/statistical_analysis/math_functions.py
@@ -7,6 +7,16 @@ def z_score(seq: np.array):
     return seq
 
 def pearson_correlation(seq: pd.DataFrame):
-    corr = (1/len(seq)-1) * (seq.T * seq)
+    """Pearson correlation matrix between the columns of ``seq``.
+
+    The previous implementation was ``(1/len(seq)-1) * (seq.T * seq)`` which, besides the
+    operator-precedence slip (``1/len - 1`` instead of ``1/(len-1)``), used an element-wise
+    product rather than a matrix product and never normalized by the standard deviations, so
+    it did not compute a correlation at all.
+    """
+    centered = seq - seq.mean()
+    cov = centered.T.dot(centered) / (len(seq) - 1)
+    std = np.sqrt(np.diag(cov))
+    corr = cov / np.outer(std, std)
     return corr
 

--- a/statistical_analysis/matrices_ops.py
+++ b/statistical_analysis/matrices_ops.py
@@ -30,19 +30,16 @@ class MatricesOperations:
         return np.allclose(matrix, matrix.T, rtol=rtol, atol=atol)
 
     @classmethod
-    def drop_symmetric_side_of_a_matrix(cls, matrix:pd.DataFrame, drop_diagonal: bool = True):
+    def drop_symmetric_side_of_a_matrix(cls, matrix: pd.DataFrame, drop_diagonal: bool = True):
         if not cls.is_symmetric(matrix):
-            raise(ValueError, "Input matrix shape should be symmetric")
-        h,w = matrix.shape
-        # Wa want the main diagonal with no off-set
-        k = 0
-        if drop_diagonal:
-            # Set np.nan in diagonal position
-            matrix.values[np.diag_indices(h)] = np.nan
-        # Pull the lower triangle of the symmetric matrix and flatten the results
-        lower_triangle: np.array = matrix.values[np.tril_indices(h, k=k)]
-        # Drop nan values if existed
-        lower_triangle = lower_triangle[~np.isnan(lower_triangle)]
+            raise ValueError("Input matrix shape should be symmetric")
+        # Copy so we never mutate the caller's matrix; the previous implementation wrote
+        # NaNs into the input's diagonal in place.
+        values = np.asarray(matrix).copy()
+        h = values.shape[0]
+        # k = -1 excludes the main diagonal; k = 0 keeps it.
+        k = -1 if drop_diagonal else 0
+        lower_triangle: np.array = values[np.tril_indices(h, k=k)]
         return lower_triangle
 
     @classmethod

--- a/tests/test_math_functions.py
+++ b/tests/test_math_functions.py
@@ -1,8 +1,4 @@
-"""statistical_analysis.math_functions — z_score and pearson_correlation.
-
-These pin *current* behavior. `pearson_correlation` is almost certainly buggy (see the note on
-its test) and is revisited in the bug-fix phase.
-"""
+"""statistical_analysis.math_functions — z_score and pearson_correlation."""
 import numpy as np
 import pandas as pd
 
@@ -23,13 +19,15 @@ def test_z_score_constant_sequence_is_nan():
     assert np.isnan(z).all()
 
 
-def test_pearson_correlation_current_behavior():
-    # BUG (pinned): `(1/len(seq)-1)` parses as (1/len)-1 rather than 1/(len-1), and
-    # `seq.T * seq` is an element-wise product, not a matrix/correlation product. So this
-    # does not compute a Pearson correlation. Locked here as-is; fixed in the bug-fix phase.
-    seq = pd.DataFrame([[1.0, 2.0], [3.0, 4.0]])
+def test_pearson_correlation_matches_pandas_corr():
+    seq = pd.DataFrame({
+        "a": [1.0, 2.0, 3.0, 4.0],
+        "b": [2.0, 4.0, 6.0, 8.0],    # perfectly correlated with a
+        "c": [4.0, 3.0, 2.0, 1.0],    # perfectly anti-correlated with a
+    })
     out = pearson_correlation(seq)
-    expected = (1 / len(seq) - 1) * (seq.T * seq)
-    pd.testing.assert_frame_equal(out, expected)
-    # concretely, for this input:
-    assert out.values.tolist() == [[-0.5, -3.0], [-3.0, -8.0]]
+    # correct Pearson correlation matrix (cross-checked against pandas)
+    pd.testing.assert_frame_equal(out, seq.corr())
+    assert np.isclose(out.loc["a", "b"], 1.0)
+    assert np.isclose(out.loc["a", "c"], -1.0)
+    assert np.allclose(np.diag(out), 1.0)

--- a/tests/test_matrices_ops.py
+++ b/tests/test_matrices_ops.py
@@ -53,8 +53,15 @@ def test_drop_symmetric_keeps_diagonal_when_requested():
     assert out.tolist() == [1.0, 2.0, 4.0, 3.0, 5.0, 6.0]
 
 
-def test_drop_symmetric_on_nonsymmetric_raises():
+def test_drop_symmetric_on_nonsymmetric_raises_value_error():
     m = pd.DataFrame(np.array([[1.0, 2.0], [3.0, 4.0]]))
-    # BUG (pinned): `raise(ValueError, msg)` raises a tuple -> TypeError, not ValueError.
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         MO.drop_symmetric_side_of_a_matrix(m)
+
+
+def test_drop_symmetric_does_not_mutate_input():
+    m = pd.DataFrame(np.array([[1.0, 2, 3], [2, 4, 5], [3, 5, 6]]))
+    before = m.to_numpy().copy()
+    MO.drop_symmetric_side_of_a_matrix(m, drop_diagonal=True)
+    # the diagonal must be untouched (previous implementation wrote NaNs into it)
+    assert np.array_equal(m.to_numpy(), before)


### PR DESCRIPTION
## What & why

Fixes the two algorithm bugs surfaced by the Phase 1 characterization tests. Each test moved from pinning the buggy behavior to asserting the correct behavior.

### 1. `matrices_ops.drop_symmetric_side_of_a_matrix`
- `raise(ValueError, msg)` raised a **tuple → `TypeError`** on non-symmetric input. Now `raise ValueError(msg)`.
- It also **mutated the caller's matrix** in place (`matrix.values[np.diag_indices(h)] = np.nan`). Rewritten to copy and take the strictly-lower triangle directly via `np.tril_indices(k=-1)`. The numeric output is **unchanged** (verified), but the input is no longer mutated and the fragile set-NaN-then-drop-NaN logic is gone.
- Used in the core paths (`relational_coding_base.relational_distance`, `fmri_connectivity_matrices`, `correlation_pipelines`), all of which pass symmetric matrices — so the happy path is unaffected; this hardens the error path and removes a destructive side effect.

### 2. `math_functions.pearson_correlation`
Was `(1/len(seq)-1) * (seq.T * seq)` — an operator-precedence slip (`1/len - 1`) plus an element-wise product with no normalization, so it wasn't a correlation at all. Now returns the Pearson correlation matrix of the columns, **cross-checked against `DataFrame.corr()`** in the test. No production callers (dead code), so zero blast radius.

> Note: `generate_heat_map`'s inline `plt.show()` (flagged in Phase 1) is left as-is — it's an unused *display* helper, so `plt.show()` is appropriate there rather than a defect.

## Verification
- **30 tests pass**.

## Merge order
Off `master`, after #2 (already merged). Independent of later phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)