### PR TITLE
chore(phase 3): make config path roots environment-overridable

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,23 +3,32 @@ import os
 import pandas as pd
 
 ROOT_PATH = os.path.abspath(os.path.curdir)
-MODELS_PATH = os.path.join(ROOT_PATH, 'saved_models')
-MODELS_NETWORKS_PATH = os.path.join(ROOT_PATH, 'saved_models', 'networks', 'models')
-ACTIVATIONS_NETWORKS_PATH = os.path.join(ROOT_PATH, 'saved_models', 'networks', 'activations')
-ACTIVATION_MATRICES = os.path.join(ROOT_PATH, 'activation_matrices')
-AVG_ACTIVATION_MATRICES = os.path.join(ROOT_PATH, 'activation_matrices', 'Avg subjects')
-FMRI_DATA = os.path.join(ROOT_PATH, 'fmri_data')
-FMRI_DATA_NETWORKS = os.path.join(ROOT_PATH, 'fmri_data', 'networks_df')
-CONNECTIVITY_FOLDER = os.path.join(ROOT_PATH, 'fmri_connectivity_matrices')
-MAPPINGS_PATH = os.path.join(ROOT_PATH, 'mappings')
-CORRELATION_MATRIX = os.path.join(ROOT_PATH, 'Correlation Matrix')
-CORRELATION_MATRIX_BY_TR = os.path.join(ROOT_PATH, 'Correlation Matrix', 'Correlation by tr')
-CORRELATION_MATRIX_REST_CLIP = os.path.join(ROOT_PATH, 'Correlation Matrix',
+
+# Data and outputs live under the repo by default. Override either root with an environment
+# variable to point at an external drive without editing this file.
+DATA_ROOT = os.environ.get('LSTM_DATA_DIR', ROOT_PATH)
+OUTPUT_ROOT = os.environ.get('LSTM_OUTPUT_DIR', ROOT_PATH)
+
+# Outputs: trained models, activation matrices, correlation/connectivity results, figures
+MODELS_PATH = os.path.join(OUTPUT_ROOT, 'saved_models')
+MODELS_NETWORKS_PATH = os.path.join(OUTPUT_ROOT, 'saved_models', 'networks', 'models')
+ACTIVATIONS_NETWORKS_PATH = os.path.join(OUTPUT_ROOT, 'saved_models', 'networks', 'activations')
+ACTIVATION_MATRICES = os.path.join(OUTPUT_ROOT, 'activation_matrices')
+AVG_ACTIVATION_MATRICES = os.path.join(OUTPUT_ROOT, 'activation_matrices', 'Avg subjects')
+CONNECTIVITY_FOLDER = os.path.join(OUTPUT_ROOT, 'fmri_connectivity_matrices')
+CORRELATION_MATRIX = os.path.join(OUTPUT_ROOT, 'Correlation Matrix')
+CORRELATION_MATRIX_BY_TR = os.path.join(OUTPUT_ROOT, 'Correlation Matrix', 'Correlation by tr')
+CORRELATION_MATRIX_REST_CLIP = os.path.join(OUTPUT_ROOT, 'Correlation Matrix',
                                             'Rest-clips correlation')
-RESULTS_PATH = os.path.join(ROOT_PATH, 'results')
-RESULTS_PATH_NETWORKS = os.path.join(ROOT_PATH, 'results', 'networks')
-FIGURES_PATH = os.path.join(ROOT_PATH, 'figures')
-PARCEL_DIR = os.path.join(ROOT_PATH, 'fmri_data', 'cifti')
+RESULTS_PATH = os.path.join(OUTPUT_ROOT, 'results')
+RESULTS_PATH_NETWORKS = os.path.join(OUTPUT_ROOT, 'results', 'networks')
+FIGURES_PATH = os.path.join(OUTPUT_ROOT, 'figures')
+
+# Inputs: preprocessed fMRI data, parcellation files, subject mappings
+FMRI_DATA = os.path.join(DATA_ROOT, 'fmri_data')
+FMRI_DATA_NETWORKS = os.path.join(DATA_ROOT, 'fmri_data', 'networks_df')
+PARCEL_DIR = os.path.join(DATA_ROOT, 'fmri_data', 'cifti')
+MAPPINGS_PATH = os.path.join(DATA_ROOT, 'mappings')
 
 TEST_SUBJECTS_AMOUNT = 76
 TRAIN_SUBJECTS_AMOUNT = 100

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,53 @@
+"""config.py path roots: repo-relative defaults + LSTM_DATA_DIR / LSTM_OUTPUT_DIR overrides."""
+import importlib
+import os
+
+import pytest
+
+import config as config_module
+
+ENV_VARS = ["LSTM_DATA_DIR", "LSTM_OUTPUT_DIR"]
+
+
+@pytest.fixture
+def reload_config():
+    """Reload config under the current environment; restore defaults afterwards."""
+    def _reload():
+        return importlib.reload(config_module)
+
+    yield _reload
+    for key in ENV_VARS:
+        os.environ.pop(key, None)
+    importlib.reload(config_module)
+
+
+def test_defaults_are_repo_relative(reload_config, monkeypatch):
+    for key in ENV_VARS:
+        monkeypatch.delenv(key, raising=False)
+    c = reload_config()
+    assert c.DATA_ROOT == c.ROOT_PATH
+    assert c.OUTPUT_ROOT == c.ROOT_PATH
+    assert c.FMRI_DATA == os.path.join(c.ROOT_PATH, "fmri_data")
+    assert c.RESULTS_PATH == os.path.join(c.ROOT_PATH, "results")
+
+
+def test_data_dir_override_moves_inputs_only(reload_config, monkeypatch):
+    monkeypatch.delenv("LSTM_OUTPUT_DIR", raising=False)
+    monkeypatch.setenv("LSTM_DATA_DIR", "/tmp/data")
+    c = reload_config()
+    assert c.FMRI_DATA == os.path.join("/tmp/data", "fmri_data")
+    assert c.PARCEL_DIR == os.path.join("/tmp/data", "fmri_data", "cifti")
+    assert c.MAPPINGS_PATH == os.path.join("/tmp/data", "mappings")
+    # outputs stay under the repo root
+    assert c.RESULTS_PATH == os.path.join(c.ROOT_PATH, "results")
+
+
+def test_output_dir_override_moves_outputs_only(reload_config, monkeypatch):
+    monkeypatch.delenv("LSTM_DATA_DIR", raising=False)
+    monkeypatch.setenv("LSTM_OUTPUT_DIR", "/tmp/out")
+    c = reload_config()
+    assert c.RESULTS_PATH == os.path.join("/tmp/out", "results")
+    assert c.MODELS_PATH == os.path.join("/tmp/out", "saved_models")
+    assert c.CONNECTIVITY_FOLDER == os.path.join("/tmp/out", "fmri_connectivity_matrices")
+    # inputs stay under the repo root
+    assert c.FMRI_DATA == os.path.join(c.ROOT_PATH, "fmri_data")


### PR DESCRIPTION
## What & why

Phase 3 (path/config hygiene). The paths were already repo-relative (no hardcoded absolutes) and the import-time data read was made lazy in Phase 1, so what remained was making the roots overridable.

Two roots, **both defaulting to `ROOT_PATH`** (behavior unchanged unless the env vars are set):

| env var | root | covers |
| --- | --- | --- |
| `LSTM_DATA_DIR` | `DATA_ROOT` | inputs: `fmri_data`, `cifti` parcellation, `mappings` |
| `LSTM_OUTPUT_DIR` | `OUTPUT_ROOT` | outputs: `saved_models`, `activation_matrices`, connectivity/correlation results, `figures` |

Paths are now grouped by input vs. output; **all constant names are unchanged**, so the 21 consumer modules are unaffected. This lets the (large) data and results live on an external drive without editing `config.py`.

## Verification
- All 18 config constants still present; `config` imports clean.
- `tests/test_config.py` covers defaults + each override in isolation.
- **33 tests pass**.

## Merge order
Off `master`, after #3 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)