### PR TITLE
refactor(phase 5): config.py -> settings.py + .env support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Copy to `.env` and adjust to your machine. Values here override the repo-relative
+# defaults in settings.py. Loaded automatically at import time via python-dotenv.
+# Plain shell environment variables of the same name work too.
+
+# Root for input data (fmri_data, cifti parcellation, mappings).
+# Defaults to the repository root.
+LSTM_DATA_DIR=/Volumes/My_Book/lstm-activations-analysis
+
+# Root for outputs (saved_models, activation_matrices, correlation/connectivity
+# results, figures). Defaults to the repository root.
+LSTM_OUTPUT_DIR=/Volumes/My_Book/lstm-activations-analysis

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ venv/
 __pycache__/
 *.py[cod]
 .pytest_cache/
+.env

--- a/data_helpers/activations_validation.py
+++ b/data_helpers/activations_validation.py
@@ -1,5 +1,5 @@
 import os
-import config
+import settings
 from supporting_functions import _load_pkl
 import pandas as pd
 import torch
@@ -8,7 +8,7 @@ from enums import Mode
 def attach_activations_to_its_subject(activation:dict, layer: str, subjects_list: list):
     acts: torch.Tensor = activation.get(f"{layer}_activations")
     num_of_occurrences = acts.shape[0]
-    occurrences_per_subject = num_of_occurrences // config.TEST_SUBJECTS_AMOUNT  # 14 clips, 4 testretest
+    occurrences_per_subject = num_of_occurrences // settings.TEST_SUBJECTS_AMOUNT  # 14 clips, 4 testretest
 
     start=0
     for sub in range(0, num_of_occurrences, occurrences_per_subject):
@@ -25,6 +25,6 @@ def attach_activations_to_its_subject(activation:dict, layer: str, subjects_list
 
 
 if __name__ == '__main__':
-    activations_: dict = _load_pkl(os.path.join(config.MODELS_PATH, 'clips_model_activations.pkl'))
-    subject_lst = pd.read_pickle(os.path.join(config.FMRI_DATA, '4_movie_runs.pkl'))['Subject'].unique()[100:].tolist()
+    activations_: dict = _load_pkl(os.path.join(settings.MODELS_PATH, 'clips_model_activations.pkl'))
+    subject_lst = pd.read_pickle(os.path.join(settings.FMRI_DATA, '4_movie_runs.pkl'))['Subject'].unique()[100:].tolist()
     attach_activations_to_its_subject(activations_, 'lstm', subject_lst)

--- a/fmri_connectivity_matrices/fmri_sequence_comparence.py
+++ b/fmri_connectivity_matrices/fmri_sequence_comparence.py
@@ -1,5 +1,5 @@
 import os
-import config
+import settings
 import pandas as pd
 
 from enums import Mode, Network
@@ -21,10 +21,10 @@ class ConnectivitySequence:
     @staticmethod
     def load(mode: Mode, net: Network = None):
         if net:
-            data = pd.read_pickle(os.path.join(config.FMRI_DATA_NETWORKS, mode.value,
+            data = pd.read_pickle(os.path.join(settings.FMRI_DATA_NETWORKS, mode.value,
                                                f"df{net.value}.pkl"))
         else:
-            data = pd.read_pickle(os.path.join(config.FMRI_DATA,
+            data = pd.read_pickle(os.path.join(settings.FMRI_DATA,
                                                f"4_runs_{mode.value}.pkl"))
         return data
 
@@ -45,7 +45,7 @@ class ConnectivitySequence:
         df_rest = self.load(Mode.REST_BETWEEN, net)
         all_sub_last_tr_clip = []
         all_sub_rest_trs = []
-        for subject in config.sub_test_list:
+        for subject in settings.sub_test_list:
             sub_data_clip = clip_sequence[clip_sequence['Subject'] == int(subject)]
 
             sub_data_clip_tr = self.get_single_tr_seq(sub_data_clip, tr=-1)
@@ -78,12 +78,12 @@ class ConnectivitySequence:
                     rest_clip_zscore)
 
                 correlation_by_tr.setdefault(
-                    config.connectivity_mapping[clip_i], []).append(round(
+                    settings.connectivity_mapping[clip_i], []).append(round(
                     rest_clip_corr.loc[0].at[1], 3))
 
         correlation_by_tr = pd.DataFrame(correlation_by_tr)
         correlation_by_tr.to_csv(
-            f"{config.CORRELATION_MATRIX_BY_TR}\\"
+            f"{settings.CORRELATION_MATRIX_BY_TR}\\"
             f"{file_name}.csv"
         )
         print(f"Saved {file_name}")

--- a/fmri_connectivity_matrices/networks_connectivity.py
+++ b/fmri_connectivity_matrices/networks_connectivity.py
@@ -4,7 +4,7 @@ from typing import Dict, List
 
 import numpy as np
 
-import config
+import settings
 import enums
 import pandas as pd
 
@@ -23,7 +23,7 @@ class Connectivity:
         self.clips = list(self.net_df['y'].unique())
 
     def _load_net(self):
-        net = pd.read_pickle(os.path.join(config.FMRI_DATA_NETWORKS,
+        net = pd.read_pickle(os.path.join(settings.FMRI_DATA_NETWORKS,
                                           self.mode.value,
                                           ''.join(['df', self.net.value, '.pkl'])))
         return net
@@ -51,16 +51,16 @@ class Connectivity:
 
             avg_mat: np.array = MatricesOperations.get_avg_matrix(
                 (mat for mat in all_cor_mat))
-            clip_name = config.connectivity_mapping[clip]
+            clip_name = settings.connectivity_mapping[clip]
             pd.DataFrame(avg_mat).to_csv(os.path.join(
-                config.CONNECTIVITY_FOLDER, self.net.value, self.mode.value, f"connectivity_matrix_{clip_name}.csv"))
+                settings.CONNECTIVITY_FOLDER, self.net.value, self.mode.value, f"connectivity_matrix_{clip_name}.csv"))
             print(f"Saved {clip_name} clip for {self.net.name} in mode {self.mode.name} to csv")
 
     @classmethod
     def generate_connectivity_matrices(cls):
         for mode in enums.Mode:
             for net in enums.Network:
-                path = os.path.join(config.CONNECTIVITY_FOLDER, net.value, mode.value)
+                path = os.path.join(settings.CONNECTIVITY_FOLDER, net.value, mode.value)
                 if not os.path.exists(path):
                     os.makedirs(path)
                 connectivity = cls(mode=mode, net=net)

--- a/fmri_connectivity_matrices/networks_correlation.py
+++ b/fmri_connectivity_matrices/networks_correlation.py
@@ -2,13 +2,13 @@ import os
 
 from enums import Network,Mode
 import pandas as pd
-import config
+import settings
 from statistical_analysis.math_functions import z_score
 from statistical_analysis.matrices_ops import MatricesOperations
 
 
 def load_connectivity_matrix(mode, net):
-    path = os.path.join(config.CONNECTIVITY_FOLDER, net.value, mode.value)
+    path = os.path.join(settings.CONNECTIVITY_FOLDER, net.value, mode.value)
     for movie in os.listdir(path):
         data = pd.read_csv(os.path.join(path, movie), index_col=0)
         movie_name = f"{mode.value}{net.value}{movie[movie.rfind('_'):movie.find('.')]}"

--- a/fmri_connectivity_matrices/roi_connectivity.py
+++ b/fmri_connectivity_matrices/roi_connectivity.py
@@ -3,7 +3,7 @@ script for generating connectivity matrix out of 300 roi from fmri data
 """
 import pandas as pd
 
-import config
+import settings
 from enums import Mode
 from mappings.re_arranging import rearrange_clips
 from statistical_analysis.correlation_pipelines import set_activation_vectors, join_and_auto_correlate
@@ -15,12 +15,12 @@ class RoiConnectivity:
     def __init__(self):
         self.data = {Mode.CLIPS: self.__load_fmri_data('movie_runs'),
                      Mode.REST_BETWEEN: self.__load_fmri_data('runs_rest_between')}
-        self.test_subjects = config.sub_test_list.astype(int)
-        self.clips = config.connectivity_mapping.keys()
+        self.test_subjects = settings.sub_test_list.astype(int)
+        self.clips = settings.connectivity_mapping.keys()
 
     @staticmethod
     def __load_fmri_data(filename):
-        return pd.read_pickle(f"{config.FMRI_DATA}//4_{filename}.pkl")
+        return pd.read_pickle(f"{settings.FMRI_DATA}//4_{filename}.pkl")
 
     def auto_corr(self, sub, mode:Mode):
         corr_per_clip = {}
@@ -34,7 +34,7 @@ class RoiConnectivity:
             # Calculate Pearson correlation
             pearson_corr = MatricesOperations.correlation_matrix(
                 matrix=mat_zscore)
-            clip_name = config.connectivity_mapping.get(clip)
+            clip_name = settings.connectivity_mapping.get(clip)
             corr_per_clip[f"{clip_name}_{mode.value}"] = pearson_corr
         return corr_per_clip
 

--- a/model_training/cc_utils.py
+++ b/model_training/cc_utils.py
@@ -7,7 +7,7 @@ import numpy as np
 import torch
 from sklearn.metrics import confusion_matrix
 
-import config
+import settings
 from supporting_functions import _dict_to_pkl
 from model_training.torch_utils import _to_cpu
 
@@ -100,7 +100,7 @@ def _lstm_test_acc(model, X, y, X_len, max_length,
     if save_activations:
         # save predicted activations
         _dict_to_pkl(model.hidden_activations,
-                     os.path.join(config.MODELS_NETWORKS_PATH,
+                     os.path.join(settings.MODELS_NETWORKS_PATH,
                                   f'{args.net} {args.mode} 10-20 activations'))
 
     # logits to labels

--- a/model_training/dataloader.py
+++ b/model_training/dataloader.py
@@ -10,7 +10,7 @@ from torch.nn.utils.rnn import pad_sequence
 from model_training.cc_utils import _get_clip_labels
 from model_training.fmri_utils import _get_parcel
 
-import config
+import settings
 from enums import Mode
 
 K_RUNS = 4
@@ -92,7 +92,7 @@ def _clip_class_df(args):
         args.r_roi = 0
         args.r_seed = 0
 
-    load_path = (os.path.join(config.FMRI_DATA,
+    load_path = (os.path.join(settings.FMRI_DATA,
                               'data_MOVIE_runs_roi_300_net_7_ts.pkl'))
 
     with open(load_path, 'rb') as f:
@@ -103,7 +103,7 @@ def _clip_class_df(args):
                     Mode.REST_BETWEEN: 'restclip_tr_lookup',
                     Mode.COMBINED: 'combined_clip_tr_lookup'}
 
-    timing_file = pd.read_csv(os.path.join(config.FMRI_DATA,
+    timing_file = pd.read_csv(os.path.join(settings.FMRI_DATA,
                               f'{mode_mapping.get(args.mode)}.csv'))
 
     # pick either all ROIs or subnetworks

--- a/model_training/inference.py
+++ b/model_training/inference.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 import torch
 
-import config
+import settings
 from enums import Mode
 from model_training.cc_utils import _lstm_test_acc, _test_time_window
 from model_training.dataloader import _get_clip_seq
@@ -13,17 +13,17 @@ from model_training.hyperparameters import HyperParams
 
 
 def _test(model_mode: Mode, inference: Mode, tr_range: tuple = ()):
-    test_subs = config.sub_test_list
+    test_subs = settings.sub_test_list
     test_len = len(test_subs)
 
     args = HyperParams()
-    model = torch.load(os.path.join(config.MODELS_PATH,
+    model = torch.load(os.path.join(settings.MODELS_PATH,
                                     f'{model_mode.value}_model.pt'))
     args.device = torch.device('cpu')
     model.to(args.device)
     model.eval()
 
-    clip_df = pd.read_pickle(os.path.join(config.FMRI_DATA,
+    clip_df = pd.read_pickle(os.path.join(settings.FMRI_DATA,
                                           f'4_runs_{inference.value}.pkl'))
     if tr_range:
         start_tr, end_tr = tr_range
@@ -70,7 +70,7 @@ def _test(model_mode: Mode, inference: Mode, tr_range: tuple = ()):
 def _save(results: dict, path: str):
     results_ = {"test_mode":  results}
 
-    with open(os.path.join(config.RESULTS_PATH,
+    with open(os.path.join(settings.RESULTS_PATH,
                            f'{path}.pkl'),
               'wb') as f:
         pickle.dump(results_, f)

--- a/model_training/train_lstm.py
+++ b/model_training/train_lstm.py
@@ -4,7 +4,7 @@ import pickle
 import os
 import time
 
-import config
+import settings
 from enums import Mode
 from model_training.hyperparameters import HyperParams
 from supporting_functions import _dict_to_pkl
@@ -131,22 +131,22 @@ def _test(df, args):
 
 
 def run_net(args):
-    nets_path = os.path.join(config.FMRI_DATA_NETWORKS, args.mode)
+    nets_path = os.path.join(settings.FMRI_DATA_NETWORKS, args.mode)
     networks = os.listdir(nets_path)
     for net in networks:
         args.net = net.replace('df', '').replace('.pkl', '')
         res_path = f'results {args.net} {args.mode}.pkl'
         print(f"start training {args.net} in {args.mode} mode")
-        df = pd.read_pickle(os.path.join(config.FMRI_DATA_NETWORKS,
+        df = pd.read_pickle(os.path.join(settings.FMRI_DATA_NETWORKS,
                                          args.mode, net))
         results = {'test_mode': _test(df, args)}
         with open(res_path, 'wb') as f:
             pickle.dump(results, f)
 
 def run(args):
-    df = pd.read_pickle(os.path.join(config.FMRI_DATA,
+    df = pd.read_pickle(os.path.join(settings.FMRI_DATA,
                                      f"4_runs_{args.mode.value}.pkl"))
-    res_path = os.path.join(config.RESULTS_PATH, f'300 roi {args.mode.value} 0-10 tr results')
+    res_path = os.path.join(settings.RESULTS_PATH, f'300 roi {args.mode.value} 0-10 tr results')
     results = {'test_mode': _test(df, args)}
     with open(f'{res_path}.pkl', 'wb') as f:
         pickle.dump(results, f)

--- a/relational_coding/relational_coding_activations.py
+++ b/relational_coding/relational_coding_activations.py
@@ -2,7 +2,7 @@ import os
 
 import pandas as pd
 
-import config
+import settings
 from enums import Mode, Network
 from mappings.re_arranging import rearrange_clips
 from relational_coding.relational_coding_base import RelationalCoding
@@ -23,10 +23,10 @@ class RelationalCodingActivations(RelationalCoding):
         clip_per_subs = []
         for sub in sub_list:
             if net == Network.WB:
-                sub_matrix = pd.read_csv(os.path.join(config.ACTIVATION_MATRICES,
+                sub_matrix = pd.read_csv(os.path.join(settings.ACTIVATION_MATRICES,
                                                       sub, mode.value, 'activation_matrix.csv'))
             else:
-                sub_matrix = pd.read_csv(os.path.join(config.ACTIVATION_MATRICES,
+                sub_matrix = pd.read_csv(os.path.join(settings.ACTIVATION_MATRICES,
                                                       sub, mode.value,
                                                       net.value,
                                                       'activation_matrix.csv'))
@@ -40,11 +40,11 @@ class RelationalCodingActivations(RelationalCoding):
     @classmethod
     def compare_single_tr(cls, net, rest_tr):
         avg_series_per_clip = {}
-        for clip_i, clip_name in config.idx_to_clip.items():
+        for clip_i, clip_name in settings.idx_to_clip.items():
             if clip_name.startswith('test'):
                 continue
-            clip_vec = cls.avg_single_tr_vectors(net, config.sub_test_list, Mode.CLIPS, clip_name)
-            rest_vec = cls.avg_single_tr_vectors(net, config.sub_test_list, Mode.REST_BETWEEN, clip_name, rest_tr)
+            clip_vec = cls.avg_single_tr_vectors(net, settings.sub_test_list, Mode.CLIPS, clip_name)
+            rest_vec = cls.avg_single_tr_vectors(net, settings.sub_test_list, Mode.REST_BETWEEN, clip_name, rest_tr)
             avg_series_per_clip[clip_name + '_' + Mode.CLIPS.value] = clip_vec.tolist()[0]
             avg_series_per_clip[clip_name + '_' + Mode.REST_BETWEEN.value] = rest_vec.tolist()[0]
         return pd.DataFrame.from_dict(avg_series_per_clip)

--- a/relational_coding/relational_coding_fmri.py
+++ b/relational_coding/relational_coding_fmri.py
@@ -2,7 +2,7 @@ import os
 
 import pandas as pd
 
-import config
+import settings
 from enums import Network, Mode
 from mappings.re_arranging import rearrange_clips
 from relational_coding.relational_coding_base import RelationalCoding
@@ -16,12 +16,12 @@ class RelationalCodingfMRI(RelationalCoding):
 
     @staticmethod
     def _load_data(mode: Mode, network: Network):
-        net_path = os.path.join(config.FMRI_DATA_NETWORKS,
+        net_path = os.path.join(settings.FMRI_DATA_NETWORKS,
                                 mode.value,
                                 f'df{network.value}.pkl')
 
         if network == Network.WB:
-            net_path = os.path.join(config.FMRI_DATA,
+            net_path = os.path.join(settings.FMRI_DATA,
                                     f'4_runs_{mode.value}.pkl')
 
         data = pd.read_pickle(net_path)
@@ -45,13 +45,13 @@ class RelationalCodingfMRI(RelationalCoding):
     @classmethod
     def compare_clip_to_rest_single_tr(cls, movies, rest, rest_tr):
         avg_series_per_clip = {}
-        for clip_i, clip in config.connectivity_mapping.items():
+        for clip_i, clip in settings.connectivity_mapping.items():
             if clip_i == 0:
                 continue
 
             clip_vec = cls.avg_single_tr_vectors(
                 data=movies,
-                sub_list=config.sub_test_list,
+                sub_list=settings.sub_test_list,
                 tr_pos=-1,
                 clip_index=clip_i)
 
@@ -63,7 +63,7 @@ class RelationalCodingfMRI(RelationalCoding):
 
             rest_vec = cls.avg_single_tr_vectors(
                 data=rest,
-                sub_list=config.sub_test_list,
+                sub_list=settings.sub_test_list,
                 tr_pos=rest_tr,
                 clip_index=clip_i)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pandas~=1.4.3
 scipy
 matplotlib~=3.5.2
 nibabel~=4.0.2
+python-dotenv~=0.21

--- a/settings.py
+++ b/settings.py
@@ -2,6 +2,15 @@ import os
 
 import pandas as pd
 
+# Load a local .env (if present) before reading any LSTM_* overrides below.
+# python-dotenv is optional: without it, plain environment variables still work.
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:
+    pass
+
 ROOT_PATH = os.path.abspath(os.path.curdir)
 
 # Data and outputs live under the repo by default. Override either root with an environment

--- a/statistical_analysis/correlation_by_tr_window.py
+++ b/statistical_analysis/correlation_by_tr_window.py
@@ -1,7 +1,7 @@
 import os
 import pandas as pd
 
-import config
+import settings
 from mappings.re_arranging import rearrange_clips
 from statistical_analysis.correlation_pipelines import (set_activation_vectors,
                                                         auto_correlation_pipeline,
@@ -35,7 +35,7 @@ def get_window_tr_clip(mat_clip: pd.DataFrame, length: int = 19, window: str = '
 
 def auto_correlation_pipeline_custom_tr(subject: str, mode: Mode):
     corr_per_clip = {}
-    mat_path = os.path.join(config.ACTIVATION_MATRICES, subject, mode.value, 'activation_matrix.csv')
+    mat_path = os.path.join(settings.ACTIVATION_MATRICES, subject, mode.value, 'activation_matrix.csv')
     sub = _load_csv(mat_path)
     for clip in list(sub['y'].unique()):
         # Drop all columns unrelated to activation values
@@ -65,7 +65,7 @@ def avg_single_tr_vectors(sub_list, mode: Mode, clip):
     for sub in sub_list:
         # Execute clip pipeline
         sub_matrix = pd.read_csv(
-            os.path.join(config.ACTIVATION_MATRICES, sub, mode.value, 'activation_matrix.csv'))
+            os.path.join(settings.ACTIVATION_MATRICES, sub, mode.value, 'activation_matrix.csv'))
         activation_vec = get_single_tr(sub_matrix, clip)
         clip_per_subs.append(activation_vec)
     avg_series = MatricesOperations.get_avg_matrix((clip.values for clip in clip_per_subs))
@@ -74,9 +74,9 @@ def avg_single_tr_vectors(sub_list, mode: Mode, clip):
 
 def compare_cliptorest_single_tr():
     avg_series_per_clip = {}
-    for clip in config.idx_to_clip.values():
-        clip_vec = avg_single_tr_vectors(config.sub_test_list, Mode.CLIPS, clip)
-        rest_vec = avg_single_tr_vectors(config.sub_test_list, Mode.REST_BETWEEN, clip)
+    for clip in settings.idx_to_clip.values():
+        clip_vec = avg_single_tr_vectors(settings.sub_test_list, Mode.CLIPS, clip)
+        rest_vec = avg_single_tr_vectors(settings.sub_test_list, Mode.REST_BETWEEN, clip)
         avg_series_per_clip[clip + '_' + Mode.CLIPS.value] = clip_vec.tolist()[0]
         avg_series_per_clip[clip + '_' + Mode.REST_BETWEEN.value] = rest_vec.tolist()[0]
     return pd.DataFrame.from_dict(avg_series_per_clip)
@@ -93,7 +93,7 @@ def compare_cliptime_window_to_rest_between(sub_list):
         # Merging clips and rest between data frame
         corr_mat = join_and_auto_correlate(df_clip, df_rest)
         corr_mat.to_csv(
-            os.path.join(config.ACTIVATION_MATRICES, sub, f'corr_mat_first_19_tr.csv'))
+            os.path.join(settings.ACTIVATION_MATRICES, sub, f'corr_mat_first_19_tr.csv'))
         print('done', sub, 'saved to csv')
 
 

--- a/statistical_analysis/correlation_pipelines.py
+++ b/statistical_analysis/correlation_pipelines.py
@@ -1,6 +1,6 @@
 import os
 
-import config
+import settings
 
 import numpy as np
 import pandas as pd
@@ -14,9 +14,9 @@ from visualizations.plot_figure import plot_matrix
 
 def _load_csv(sub: str, mode: Mode, net: Network = None):
     if net:
-        path = os.path.join(config.ACTIVATION_MATRICES, sub, mode.value, net.value, 'activation_matrix.csv')
+        path = os.path.join(settings.ACTIVATION_MATRICES, sub, mode.value, net.value, 'activation_matrix.csv')
     else:
-        path = os.path.join(config.ACTIVATION_MATRICES, sub, mode.value, 'activation_matrix.csv')
+        path = os.path.join(settings.ACTIVATION_MATRICES, sub, mode.value, 'activation_matrix.csv')
 
     sub = pd.read_csv(path)
     return sub
@@ -60,9 +60,9 @@ def set_activation_vectors(corr: dict):
 
 
 def generate_correlation_per_clip(subject_list, mode: Mode):
-    mat_path = config.ACTIVATION_MATRICES
+    mat_path = settings.ACTIVATION_MATRICES
     all_cor_mat = []
-    for clip in config.idx_to_clip.values():
+    for clip in settings.idx_to_clip.values():
         for sub in subject_list:
             corr_mat = pd.read_csv(os.path.join(mat_path, sub, mode.value, 'activation_matrix.csv'))
             matrix = corr_mat[corr_mat['y'] == clip]
@@ -73,7 +73,7 @@ def generate_correlation_per_clip(subject_list, mode: Mode):
             (mat for mat in all_cor_mat))
         avg_mat = pd.DataFrame(avg_mat)
         avg_mat.to_csv(os.path.join(
-            config.CORRELATION_MATRIX,
+            settings.CORRELATION_MATRIX,
             f'avg_corr_mat{clip}_{mode.value}.csv'), index=False)
 
 
@@ -94,12 +94,12 @@ def main_pipeline(subjects_list, table_name, net: Network = None, re_test: bool 
         corr_mat = join_and_auto_correlate(df_clip, df_rest)
         corr_mat = rearrange_clips(corr_mat, where='rows', with_testretest=re_test)
         corr_mat = rearrange_clips(corr_mat, where='columns', with_testretest=re_test)
-        corr_mat.to_csv(os.path.join(config.ACTIVATION_MATRICES, sub, f'{table_name}.csv'))
+        corr_mat.to_csv(os.path.join(settings.ACTIVATION_MATRICES, sub, f'{table_name}.csv'))
         print('done', sub, 'saved to csv', net.name)
 
 
 def create_avg_activation_matrix(table_name: str):
-    mat_path = config.ACTIVATION_MATRICES
+    mat_path = settings.ACTIVATION_MATRICES
     all_cor_mat = []
     subjects = os.listdir(mat_path)
     for sub in subjects:
@@ -118,31 +118,31 @@ def create_avg_activation_matrix(table_name: str):
 
 
 def wb_pipeline():
-    # generate_correlation_per_clip(config.test_list, Mode.CLIPS)
-    # generate_correlation_per_clip(config.test_list, Mode.REST_BETWEEN)
+    # generate_correlation_per_clip(settings.test_list, Mode.CLIPS)
+    # generate_correlation_per_clip(settings.test_list, Mode.REST_BETWEEN)
 
     table = 'corr mat wb without test-re-test'
-    main_pipeline(config.sub_test_list, table, re_test=False)
+    main_pipeline(settings.sub_test_list, table, re_test=False)
     create_avg_activation_matrix(table)
 
-    clip_rest_corr = total_clip_and_rest_correlation(f"{config.ACTIVATION_MATRICES}\\avg {table}")
+    clip_rest_corr = total_clip_and_rest_correlation(f"{settings.ACTIVATION_MATRICES}\\avg {table}")
     clip_rest_corr.to_csv('rest-clip corr' + table + '.csv')
 
     table = 'corr mat wb with test-re-test'
-    main_pipeline(config.sub_test_list, table, re_test=True)
+    main_pipeline(settings.sub_test_list, table, re_test=True)
     create_avg_activation_matrix(table)
 
-    clip_rest_corr = total_clip_and_rest_correlation(f"{config.ACTIVATION_MATRICES}\\avg {table}")
+    clip_rest_corr = total_clip_and_rest_correlation(f"{settings.ACTIVATION_MATRICES}\\avg {table}")
     clip_rest_corr.to_csv('rest-clip corr' + table + '.csv')
 
 
 def net_pipeline():
     for net in Network:
         table = f'{net.value} corr mat without test-re-test'
-        main_pipeline(config.sub_test_list, table, net, re_test=False)
+        main_pipeline(settings.sub_test_list, table, net, re_test=False)
         create_avg_activation_matrix(table)
 
-        clip_rest_corr = total_clip_and_rest_correlation(f"{config.ACTIVATION_MATRICES}\\avg {table}")
+        clip_rest_corr = total_clip_and_rest_correlation(f"{settings.ACTIVATION_MATRICES}\\avg {table}")
         clip_rest_corr.to_csv('rest-clip corr' + table + '.csv')
 
 

--- a/statistical_analysis/correlation_sequence_comparence.py
+++ b/statistical_analysis/correlation_sequence_comparence.py
@@ -1,5 +1,5 @@
 import os
-import config
+import settings
 import pandas as pd
 import matplotlib.pyplot as plt
 
@@ -39,17 +39,17 @@ class CorrelationSequence:
     def get_subjects_average_single_tr(self, clip, net: Network = None):
         all_sub_last_tr_clip = []
         all_sub_rest_trs = []
-        for sub in os.listdir(config.ACTIVATION_MATRICES):
+        for sub in os.listdir(settings.ACTIVATION_MATRICES):
             if not sub.isdigit():
                 continue
-            sub_path = os.path.join(config.ACTIVATION_MATRICES, sub, Mode.CLIPS.value)
+            sub_path = os.path.join(settings.ACTIVATION_MATRICES, sub, Mode.CLIPS.value)
             if net:
                 sub_path = os.path.join(sub_path, net.value)
             sub_data = self.load(sub_path)
             sub_data_clip = sub_data[sub_data['y'] == clip]
             sub_data_clip_tr = self.get_single_tr_seq(sub_data_clip, tr=-1)
             all_sub_last_tr_clip.append(sub_data_clip_tr)
-            sub_path = os.path.join(config.ACTIVATION_MATRICES, sub, Mode.REST_BETWEEN.value)
+            sub_path = os.path.join(settings.ACTIVATION_MATRICES, sub, Mode.REST_BETWEEN.value)
             if net:
                 sub_path = os.path.join(sub_path, net.value)
             sub_data = self.load(sub_path)
@@ -63,7 +63,7 @@ class CorrelationSequence:
 
     def generate_sequence_comparison(self, net: Network, table_name):
         correlation_by_tr = {}
-        for clip in config.idx_to_clip.values():
+        for clip in settings.idx_to_clip.values():
             if clip.startswith('test'):
                 continue
             subs_clip, subs_rest = self.get_subjects_average_single_tr(clip, net)
@@ -79,7 +79,7 @@ class CorrelationSequence:
 
         correlation_by_tr = pd.DataFrame(correlation_by_tr)
         correlation_by_tr.to_csv(
-            f"{config.CORRELATION_MATRIX_BY_TR}\\"
+            f"{settings.CORRELATION_MATRIX_BY_TR}\\"
             f"{table_name}.csv"
         )
         print(f"Saved {table_name}")

--- a/statistical_analysis/cross_corr_clip_rest.py
+++ b/statistical_analysis/cross_corr_clip_rest.py
@@ -3,7 +3,7 @@ import os
 import numpy as np
 import pandas as pd
 
-import config
+import settings
 from enums import Mode
 from statistical_analysis.math_functions import z_score
 from statistical_analysis.matrices_ops import MatricesOperations
@@ -11,8 +11,8 @@ from statistical_analysis.matrices_ops import MatricesOperations
 
 def avg_activations_per_sub(clip, mode):
     all_cor_mat = []
-    for sub in config.sub_test_list:
-        corr_mat = pd.read_csv(os.path.join(config.ACTIVATION_MATRICES, sub, mode.value, 'activation_matrix.csv'))
+    for sub in settings.sub_test_list:
+        corr_mat = pd.read_csv(os.path.join(settings.ACTIVATION_MATRICES, sub, mode.value, 'activation_matrix.csv'))
         matrix = corr_mat[corr_mat['y'] == clip]
         matrix = matrix.drop(['y', 'tr'], axis=1)
         all_cor_mat.append(matrix)
@@ -25,7 +25,7 @@ def avg_activations_per_sub(clip, mode):
 
 def clip_rest_cross_corr():
     cross_corr_clip_rest = {}
-    for clip in config.idx_to_clip.values():
+    for clip in settings.idx_to_clip.values():
         movie_clip_avg = avg_activations_per_sub(clip, Mode.CLIPS)
         movie_clip_avg = movie_clip_avg.apply(lambda x: z_score(x))
         rest_between_avg = avg_activations_per_sub(clip, Mode.REST_BETWEEN)

--- a/statistical_analysis/table_builder.py
+++ b/statistical_analysis/table_builder.py
@@ -3,10 +3,10 @@ import os
 import pandas as pd
 import torch
 
-import config
+import settings
 from supporting_functions import _load_pkl
 from enums import Mode, Network
-from config import idx_to_clip
+from settings import idx_to_clip
 
 
 class TableBuilder:
@@ -40,7 +40,7 @@ class TableBuilder:
 
     @staticmethod
     def __create_subject_dir(subject: str, mode: Mode, network: str = ''):
-        subject_dir = os.path.join(config.ACTIVATION_MATRICES, subject)
+        subject_dir = os.path.join(settings.ACTIVATION_MATRICES, subject)
         # Open new directory as subjects id
         if not os.path.exists(subject_dir):
             os.makedirs(subject_dir)
@@ -59,7 +59,7 @@ class TableBuilder:
 
     @classmethod
     def subject_tables_forming_wb(cls, activation_path, mode: Mode):
-        subjects_mappings = _load_pkl(os.path.join(config.MAPPINGS_PATH,
+        subjects_mappings = _load_pkl(os.path.join(settings.MAPPINGS_PATH,
                                                    "subject_occurrence_mapping.pkl"))
         test_subjects = subjects_mappings.get("test")
         activations = _load_pkl(activation_path)
@@ -75,7 +75,7 @@ class TableBuilder:
 
     @classmethod
     def subject_tables_forming_networks(cls, activation_path, mode: Mode):
-        subjects_mappings = _load_pkl(os.path.join(config.MAPPINGS_PATH,
+        subjects_mappings = _load_pkl(os.path.join(settings.MAPPINGS_PATH,
                                                    "subject_occurrence_mapping.pkl"))
         test_subjects = subjects_mappings.get("test")
         for net in os.listdir(activation_path):
@@ -94,19 +94,19 @@ class TableBuilder:
 def networks_pipeline():
     table_builder = TableBuilder()
 
-    path = os.path.join(config.ACTIVATIONS_NETWORKS_PATH, Mode.CLIPS.value)
+    path = os.path.join(settings.ACTIVATIONS_NETWORKS_PATH, Mode.CLIPS.value)
     table_builder.subject_tables_forming_networks(activation_path=path, mode=Mode.CLIPS)
 
-    path = os.path.join(config.ACTIVATIONS_NETWORKS_PATH, Mode.REST_BETWEEN.value)
+    path = os.path.join(settings.ACTIVATIONS_NETWORKS_PATH, Mode.REST_BETWEEN.value)
     table_builder.subject_tables_forming_networks(activation_path=path, mode=Mode.REST_BETWEEN)
 
 def wb_pipeline():
     table_builder = TableBuilder()
 
-    path = f'{config.MODELS_PATH}\\{Mode.CLIPS.value}_model_activations.pkl'
+    path = f'{settings.MODELS_PATH}\\{Mode.CLIPS.value}_model_activations.pkl'
     table_builder.subject_tables_forming_wb(activation_path=path, mode=Mode.CLIPS)
 
-    path = f'{config.MODELS_PATH}\\{Mode.REST_BETWEEN.value}_model_activations.pkl'
+    path = f'{settings.MODELS_PATH}\\{Mode.REST_BETWEEN.value}_model_activations.pkl'
     table_builder.subject_tables_forming_wb(activation_path=path, mode=Mode.REST_BETWEEN)
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,24 +1,24 @@
-"""config.py path roots: repo-relative defaults + LSTM_DATA_DIR / LSTM_OUTPUT_DIR overrides."""
+"""settings.py path roots: repo-relative defaults + LSTM_DATA_DIR / LSTM_OUTPUT_DIR overrides."""
 import importlib
 import os
 
 import pytest
 
-import config as config_module
+import settings as settings_module
 
 ENV_VARS = ["LSTM_DATA_DIR", "LSTM_OUTPUT_DIR"]
 
 
 @pytest.fixture
 def reload_config():
-    """Reload config under the current environment; restore defaults afterwards."""
+    """Reload settings under the current environment; restore defaults afterwards."""
     def _reload():
-        return importlib.reload(config_module)
+        return importlib.reload(settings_module)
 
     yield _reload
     for key in ENV_VARS:
         os.environ.pop(key, None)
-    importlib.reload(config_module)
+    importlib.reload(settings_module)
 
 
 def test_defaults_are_repo_relative(reload_config, monkeypatch):

--- a/visualizations/inference_results.py
+++ b/visualizations/inference_results.py
@@ -12,7 +12,7 @@ import plotly.io as pio
 import plotly.express as px
 from plotly.subplots import make_subplots
 
-import config
+import settings
 
 pio.templates.default = 'plotly_white'
 from plot_utils import _hex_to_rgb, _plot_ts
@@ -60,7 +60,7 @@ args = ARGS()
 
 
 def _get_results(args, model, networks=None):
-    res_path = config.RESULTS_PATH if not networks else config.RESULTS_PATH_NETWORKS
+    res_path = settings.RESULTS_PATH if not networks else settings.RESULTS_PATH_NETWORKS
     load_path = os.path.join(res_path,model)
     with open(load_path, 'rb') as f:
         r = pickle.load(f)
@@ -175,7 +175,7 @@ def _compare_temporal(models, clip_names, mode='train_mode'):
 
 def _get_labels():
 
-    timing_file = pd.read_csv(os.path.join(config.FMRI_DATA,
+    timing_file = pd.read_csv(os.path.join(settings.FMRI_DATA,
                               f'videoclip_tr_lookup.csv'))
 
     clip_y = _get_clip_labels(timing_file)

--- a/visualizations/plot_bar.py
+++ b/visualizations/plot_bar.py
@@ -1,5 +1,5 @@
 import os
-import config
+import settings
 import matplotlib.pyplot as plt
 
 import pandas as pd
@@ -8,7 +8,7 @@ import pandas as pd
 
 def plot_rest_clip_correlation_bar():
     res = {}
-    res_path = config.RESULTS_PATH_NETWORKS
+    res_path = settings.RESULTS_PATH_NETWORKS
     for net in os.listdir(res_path):
         rest_clip_corr = pd.read_csv(os.path.join(res_path, net))
         net_name = net.split()[1].replace('corr','')

--- a/visualizations/plot_figure.py
+++ b/visualizations/plot_figure.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-import config
+import settings
 from enums import Network, DataType
 from supporting_functions import _load_pkl
 
@@ -14,7 +14,7 @@ def save_matrix_as_image():
     MEDIUM_SIZE = 10
     BIGGER_SIZE = 12
     mat_path = os.path.join(
-        config.DATA_PATH, 'activations_matrices', 'avrage_accross_all_subjects')
+        settings.DATA_PATH, 'activations_matrices', 'avrage_accross_all_subjects')
     for array in os.listdir(f'{mat_path}\\csvis'):
         if not array.isdigit():
             continue

--- a/visualizations/plot_fmri_signal.py
+++ b/visualizations/plot_fmri_signal.py
@@ -2,7 +2,7 @@ import os
 
 import numpy as np
 import pandas as pd
-import config
+import settings
 import matplotlib.pyplot as plt
 from statistical_analysis.matrices_ops import MatricesOperations
 
@@ -11,9 +11,9 @@ K_RUNS = 4
 
 def load_fmri_data(file, net=None):
     if net:
-        df = pd.read_pickle(os.path.join(config.FMRI_DATA, 'networks_df', f'{file}.pkl'))
+        df = pd.read_pickle(os.path.join(settings.FMRI_DATA, 'networks_df', f'{file}.pkl'))
     else:
-        df = pd.read_pickle(os.path.join(config.FMRI_DATA, f'{file}.pkl'))
+        df = pd.read_pickle(os.path.join(settings.FMRI_DATA, f'{file}.pkl'))
     return df
 
 
@@ -49,7 +49,7 @@ def avg_roi_seq(signals, clip_i):
             one_dimension_sig[signal] = roi_avg
     else:
         # average roi
-        signal = config.idx_to_clip.get(clip_i)
+        signal = settings.idx_to_clip.get(clip_i)
         roi_avg = MatricesOperations.get_avg_matrix(iter(signals), axis=1)
         one_dimension_sig[signal] = roi_avg
 
@@ -59,7 +59,7 @@ def avg_roi_seq(signals, clip_i):
 def iterate_subs(clip_i, mode):
     df_clips = load_fmri_data('4_movie_runs')
     subjects_signals = {}
-    for subject in config.sub_test_list:
+    for subject in settings.sub_test_list:
         subject = int(subject)
         seq_signals = filter_wanted_signal(df_clips, subject, clip_i)
 
@@ -74,7 +74,7 @@ def iterate_subs(clip_i, mode):
 
 def average_all_subjects(subjects_signals, clip_i,  test_retest: bool = False, concat_test_retest: bool = False):
     avg_seq = {}
-    clip = config.connectivity_mapping.get(clip_i)
+    clip = settings.connectivity_mapping.get(clip_i)
     if test_retest:
         all_subjects = {}
         for sub, seqs in subjects_signals.items():
@@ -132,15 +132,15 @@ def plot_signal(signal, clip):
 if __name__ == '__main__':
     inception = 5
     avg_signal = iterate_subs(clip_i=inception, mode=None)
-    clip_name = config.idx_to_clip.get(inception)
+    clip_name = settings.idx_to_clip.get(inception)
     plot_signal(avg_signal, clip_name)
 
     pockets = 3
     avg_signal = iterate_subs(clip_i=pockets, mode=None)
-    clip_name = config.idx_to_clip.get(pockets)
+    clip_name = settings.idx_to_clip.get(pockets)
     plot_signal(avg_signal, clip_name)
 
     testretest = 0
     avg_signal = iterate_subs(clip_i=testretest, mode=None)
-    clip_name = config.idx_to_clip.get(testretest)
+    clip_name = settings.idx_to_clip.get(testretest)
     plot_signal(avg_signal, clip_name)

--- a/visualizations/sub_plot.py
+++ b/visualizations/sub_plot.py
@@ -4,7 +4,7 @@ import pandas as pd
 from matplotlib import colors
 from matplotlib import pyplot as plt
 
-import config
+import settings
 from enums import Network
 from statistical_analysis.matrices_ops import MatricesOperations
 from supporting_functions import _load_pkl
@@ -59,7 +59,7 @@ def plot_signals_on_top(data, title):
     fig1 = plt.gcf()
     plt.show()
     plt.draw()
-    fig1.savefig(fr"{config.FIGURES_PATH}\\{title}.png", dpi=100)
+    fig1.savefig(fr"{settings.FIGURES_PATH}\\{title}.png", dpi=100)
 
 
 def _subplot(table_path, title):
@@ -68,12 +68,12 @@ def _subplot(table_path, title):
 
 
 def _plot_wb():
-    table_path = f'{config.CORRELATION_MATRIX_BY_TR}\\' \
+    table_path = f'{settings.CORRELATION_MATRIX_BY_TR}\\' \
                  f'fmri last tr clip correlation with rest between without test-re-test.csv'
 
     _subplot(table_path, "fMRI Last tr clip Correlation with Resting state")
 
-    table_path = f'{config.CORRELATION_MATRIX_BY_TR}\\' \
+    table_path = f'{settings.CORRELATION_MATRIX_BY_TR}\\' \
                  f'last tr clip correlation with rest between without test-re-test.csv'
     title = "LSTM patterns similarity last tr clip with rest between"
     _subplot(table_path, title)
@@ -84,14 +84,14 @@ def _plot_networks(data_type):
         table_name = f"{data_type} {net.value}" \
                      f" last tr clip correlation with rest between without test-re-test"
         tables_path = os.path.join(
-            config.CORRELATION_MATRIX_BY_TR,
+            settings.CORRELATION_MATRIX_BY_TR,
             f"{table_name}.csv")
         _subplot(tables_path, table_name)
 
 
 def _plot_combined_avg_wb_and_networks(data_type):
     combined_dict = {}
-    wb_path = f'{config.CORRELATION_MATRIX_BY_TR}\\' \
+    wb_path = f'{settings.CORRELATION_MATRIX_BY_TR}\\' \
               f'{data_type} WB last tr clip correlation with rest between without test-re-test.csv'
     wb_df = pd.read_csv(wb_path, index_col=0)
     for ii, movie in wb_df.iterrows():
@@ -102,7 +102,7 @@ def _plot_combined_avg_wb_and_networks(data_type):
         table_name = f"{data_type} {net.value}" \
                      f" last tr clip correlation with rest between without test-re-test"
         net_path = os.path.join(
-            config.CORRELATION_MATRIX_BY_TR,
+            settings.CORRELATION_MATRIX_BY_TR,
             f"{table_name}.csv")
 
         net_df = pd.read_csv(net_path, index_col=0)


### PR DESCRIPTION
## What & why

Phase 5: adopt the `settings.py` convention and support a local `.env` for the machine-specific data/output roots (added in Phase 3).

- **`config.py` → `settings.py`** (`git mv`). Every importer updated: `import config` / `config.X` → `import settings` / `settings.X` across 21 modules, plus the one `from config import idx_to_clip`. Verified no `from config import` remnants and no `.config.` attribute chains before the mechanical rewrite.
- **`.env` loading** in `settings.py` via `python-dotenv`, run *before* the `LSTM_*` overrides are read. Optional import (`try/except ImportError`) so plain env vars still work and the repo doesn't hard-break without the package.
- **`.env.example`** documents `LSTM_DATA_DIR` / `LSTM_OUTPUT_DIR`; `.env` is gitignored.
- `python-dotenv` added to `requirements.txt`.
- `tests/test_config.py` → `tests/test_settings.py`, retargeted.

## Verification
- No leftover `config` references; `settings` imports (dotenv optional path exercised).
- **34 tests pass**.

## Merge order
Off `master`, after #5 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)