### PR TITLE
feat(phase 7): CLI + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,92 @@
-# LstmActivationsAnalysis
-fmri signals processed in rnn models
+# LSTM Activations Analysis
+
+Analysis of fMRI signals processed through recurrent (LSTM) models. The pipeline parcellates
+Human Connectome Project (HCP) 7T movie-watching and resting-state scans into ROI/network time
+series, trains an LSTM to classify movie clips from those time series, and then studies the
+model's internal **activations** — how the network represents clips versus nearby rest, via
+relational coding, connectivity, and correlation statistics.
+
+> This repository accompanies ongoing, unpublished research. It describes the algorithms and
+> how to run them; it intentionally contains no findings or citations.
+
+## What it does
+
+1. **Parcellation** — raw CIFTI movie/rest data → Schaefer-2018 ROI (300) / 7-network time series.
+2. **Model training** — an LSTM clip-classifier over the ROI/network time series.
+3. **Activation analysis** — extract the model's activations and compare clip vs. rest structure:
+   - **relational coding** — task-vs-rest relational distance per clip;
+   - **connectivity** — per-network connectivity matrices;
+   - **correlation pipelines** — whole-brain / per-network activation correlations.
+
+## Layout
+
+```
+settings.py               # paths + LSTM_DATA_DIR / LSTM_OUTPUT_DIR (.env) overrides
+enums.py                  # Mode / Network / DataType
+cli.py                    # command-line interface over the main workflows
+parcellation/             # raw CIFTI -> ROI/network time series (own argparse script)
+model_training/           # LSTM model, dataloader, training, inference, cc/torch utils
+relational_coding/        # task-vs-rest relational-coding distances
+fmri_connectivity_matrices/  # network connectivity matrices
+statistical_analysis/     # correlation pipelines + math/matrix helpers
+mappings/                 # clip/rest ordering and subject mappings
+visualizations/           # plotting helpers
+supporting_functions.py   # pickle / csv I/O helpers
+tests/                    # pytest suite (algorithms, config, CLI)
+```
+
+## Setup
+
+Dependencies are managed with [uv](https://docs.astral.sh/uv/). Version pins mirror the
+validated environment (Python 3.10, torch 1.12); results depend on them, so avoid bumping.
+
+```bash
+uv sync                 # create the environment from pyproject.toml + uv.lock
+uv run pytest           # run the test suite
+```
+
+## Configuration
+
+Data and outputs live under the repo by default. `settings.py` reads two roots from the
+environment or a local `.env`; copy the template and edit it:
+
+```bash
+cp .env.example .env
+```
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `LSTM_DATA_DIR` | repo root | inputs: `fmri_data`, `cifti` parcellation, `mappings` |
+| `LSTM_OUTPUT_DIR` | repo root | outputs: `saved_models`, `activation_matrices`, correlation/connectivity results, `figures` |
+
+A full run expects the preprocessed fMRI tables and trained models to already exist under
+those paths.
+
+## Running
+
+```bash
+uv run python -m cli train --mode rest_between --epochs 50
+uv run python -m cli infer --model-mode combined --inference rest_between
+uv run python -m cli correlation --scope net
+uv run python -m cli relational-coding --shuffle
+uv run python -m cli connectivity
+```
+
+`python -m cli --help` (or `<command> --help`) lists all options. The underlying functions
+remain importable from their modules for use in notebooks/scripts.
+
+Raw-data parcellation keeps its own script:
+
+```bash
+uv run python parcellation/parcellation.py --input-data <cifti> --output-data <roi> --roi 300 --net 7
+```
+
+## Testing
+
+```bash
+uv run pytest
+```
+
+The suite covers the pure algorithm/helper code (analytic checks and characterization on
+synthetic data), the settings/env overrides, and the CLI wiring. It uses only synthetic
+fixtures, so it runs without the HCP data on disk.

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,109 @@
+"""Command-line interface for the main LSTM-activations-analysis workflows.
+
+Each subcommand fronts an existing entry point. Heavy modules (torch, the pipelines) are
+imported lazily inside the handlers, so building the parser is cheap and side-effect free.
+
+    python -m cli train --mode rest_between --epochs 50
+    python -m cli infer --model-mode combined --inference rest_between
+    python -m cli correlation --scope net
+    python -m cli relational-coding --shuffle
+    python -m cli connectivity
+
+Workflows read/write data under the paths configured in settings.py (see .env.example),
+so a real run needs the preprocessed fMRI tables / trained models on disk. Raw-data
+parcellation has its own script: ``python parcellation/parcellation.py --help``.
+"""
+import argparse
+
+MODES = ["clips", "rest_between", "combined"]
+
+
+def _run_train(args):
+    from enums import Mode
+    from model_training import train_lstm
+    from model_training.hyperparameters import HyperParams
+
+    hp = HyperParams()
+    hp.mode = Mode(args.mode)
+    if args.epochs is not None:
+        hp.num_epochs = args.epochs
+    if args.batch_size is not None:
+        hp.batch_size = args.batch_size
+    (train_lstm.run_net if args.per_network else train_lstm.run)(hp)
+
+
+def _run_infer(args):
+    from enums import Mode
+    from model_training import inference
+
+    tr_range = tuple(args.tr_range) if args.tr_range else ()
+    results, res_path = inference._test(
+        model_mode=Mode(args.model_mode), inference=Mode(args.inference), tr_range=tr_range)
+    inference._save(results, res_path)
+
+
+def _run_connectivity(args):
+    from fmri_connectivity_matrices.networks_connectivity import Connectivity
+
+    Connectivity.generate_connectivity_matrices()
+
+
+def _run_relational_coding(args):
+    from relational_coding.relational_coding_fmri import RelationalCodingfMRI
+
+    RelationalCodingfMRI.shuffle = args.shuffle
+    RelationalCodingfMRI.executor(with_retest=args.with_retest)
+
+
+def _run_correlation(args):
+    from statistical_analysis import correlation_pipelines as cp
+
+    (cp.wb_pipeline if args.scope == "wb" else cp.net_pipeline)()
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        prog="lstm-activations-analysis",
+        description="Train the LSTM and run the activation / relational-coding analyses.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p = sub.add_parser("train", help="train the clip-classification LSTM")
+    p.add_argument("--mode", choices=MODES, default="rest_between", help="data mode to train on")
+    p.add_argument("--epochs", type=int, default=None, help="override HyperParams.num_epochs")
+    p.add_argument("--batch-size", type=int, default=None, help="override HyperParams.batch_size")
+    p.add_argument("--per-network", action="store_true",
+                   help="train one model per network (run_net) instead of the 300-ROI model")
+    p.set_defaults(handler=_run_train)
+
+    p = sub.add_parser("infer", help="run a trained model and save test results / activations")
+    p.add_argument("--model-mode", choices=MODES, required=True, help="which trained model to load")
+    p.add_argument("--inference", choices=MODES, required=True, help="data mode to run inference on")
+    p.add_argument("--tr-range", type=int, nargs=2, metavar=("START", "END"), default=None,
+                   help="optional TR window, e.g. --tr-range 10 20")
+    p.set_defaults(handler=_run_infer)
+
+    p = sub.add_parser("connectivity", help="generate network connectivity matrices")
+    p.set_defaults(handler=_run_connectivity)
+
+    p = sub.add_parser("relational-coding", help="fMRI relational-coding distances")
+    p.add_argument("--shuffle", action="store_true", help="shuffle clip labels (permutation control)")
+    p.add_argument("--with-retest", action="store_true", help="include the test-retest clips")
+    p.set_defaults(handler=_run_relational_coding)
+
+    p = sub.add_parser("correlation", help="activation correlation pipelines")
+    p.add_argument("--scope", choices=["wb", "net"], default="wb",
+                   help="whole-brain (wb) or per-network (net) pipeline")
+    p.set_defaults(handler=_run_correlation)
+
+    return parser
+
+
+def run(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    args.handler(args)
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,55 @@
+"""CLI wiring: argument parsing and subcommand -> handler dispatch (no workflow executed)."""
+import pytest
+
+import cli
+
+
+def _parse(argv):
+    return cli.build_parser().parse_args(argv)
+
+
+def test_requires_a_subcommand():
+    with pytest.raises(SystemExit):
+        _parse([])
+
+
+def test_unknown_subcommand_errors():
+    with pytest.raises(SystemExit):
+        _parse(["nope"])
+
+
+def test_train_defaults_and_overrides():
+    a = _parse(["train"])
+    assert a.handler is cli._run_train
+    assert a.mode == "rest_between" and a.epochs is None and a.per_network is False
+    b = _parse(["train", "--mode", "clips", "--epochs", "10", "--per-network"])
+    assert b.mode == "clips" and b.epochs == 10 and b.per_network is True
+
+
+def test_train_rejects_bad_mode():
+    with pytest.raises(SystemExit):
+        _parse(["train", "--mode", "banana"])
+
+
+def test_infer_requires_modes_and_parses_range():
+    with pytest.raises(SystemExit):
+        _parse(["infer"])  # --model-mode / --inference required
+    a = _parse(["infer", "--model-mode", "combined", "--inference", "rest_between",
+                "--tr-range", "10", "20"])
+    assert a.handler is cli._run_infer
+    assert a.model_mode == "combined" and a.inference == "rest_between"
+    assert a.tr_range == [10, 20]
+
+
+def test_connectivity_and_relational_coding():
+    assert _parse(["connectivity"]).handler is cli._run_connectivity
+    rc = _parse(["relational-coding", "--shuffle", "--with-retest"])
+    assert rc.handler is cli._run_relational_coding
+    assert rc.shuffle is True and rc.with_retest is True
+    assert _parse(["relational-coding"]).shuffle is False
+
+
+def test_correlation_scope():
+    assert _parse(["correlation"]).scope == "wb"
+    a = _parse(["correlation", "--scope", "net"])
+    assert a.handler is cli._run_correlation and a.scope == "net"


### PR DESCRIPTION
## What & why

Phase 7 (final): a command-line interface over the main workflows and a real README.

- **`cli.py`** — one entry point with subcommands: `train`, `infer`, `connectivity`, `relational-coding`, `correlation`. Each fronts an existing entry function; heavy modules (torch, the pipelines) are imported **lazily inside the handlers**, so building the parser is cheap, side-effect free, and unit-testable. Raw-data parcellation keeps its own self-contained argparse script (documented in the README rather than re-wrapped).
- **`tests/test_cli.py`** — 7 tests covering argument parsing + subcommand→handler dispatch. No workflow is executed and no data is required.
- **`README.md`** — full rewrite: pipeline overview (parcellation → LSTM training → activation analysis), `uv` setup, `.env` configuration table, CLI usage, testing. No paper citation or findings (unpublished).

## Verification
- `compileall` clean · all 5 subcommands wire to a handler · **41 tests pass** (34 + 7 CLI).

## Merge order
Off `master`, after #7 (merged). Final phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)